### PR TITLE
fix constructor alias

### DIFF
--- a/alias.lua
+++ b/alias.lua
@@ -12,13 +12,16 @@ minetest.register_alias("moremesecons_playerkiller:playerkiller","air")
 minetest.register_alias("pipeworks:dispenser_off","air")
 minetest.register_alias("basic_machines:recycler","air")
 -- weird issue with multicraft where entire server was filled with
+
 -- display node
 minetest.register_alias("postool:display_node","air")
--- these blocks are not useful, should be disabled in the mod
-minetest.register_alias("basic_machines:enviro","air")
-minetest.register_alias("basic_machines:ball_spawner","air")
 -- smk hates constructors
-minetest.register_alias("technic:constructor_mk1_off","air")
-minetest.register_alias("technic:constructor_mk2_off","air")
-minetest.register_alias("technic:constructor_mk3_off","air")
+minetest.register_alias_force("technic:constructor_mk1_off","air")
+minetest.register_alias_force("technic:constructor_mk2_off","air")
+minetest.register_alias_force("technic:constructor_mk3_off","air")
+-- these blocks are not useful, should be disabled in the mod
+minetest.register_alias_force("basic_machines:ball_spawner","air")
+
+-- spaaaaaaace...
+--minetest.register_alias_force("basic_machines:enviro","air")
 

--- a/mod.conf
+++ b/mod.conf
@@ -1,5 +1,5 @@
 name = smk_custom
-depends = default, sethome, farming
+depends = default, sethome, farming, basic_machines, technic
 optional_depends = """
 skybox,
 beacon,


### PR DESCRIPTION
Forces constructor aliases which were not working because the node was already defined. This spawns discussion about the other aliases which appear to be working despite already being defined.

Also modifying mod.conf for the dependency list.